### PR TITLE
Python 2 to 3, two other errors

### DIFF
--- a/clinvar/clinvar_hgvs.py
+++ b/clinvar/clinvar_hgvs.py
@@ -76,8 +76,8 @@ if __name__ == '__main__':
 
     context = etree.iterparse(xml, events=('start', 'end'))
     context = iter(context)
-    event, root = context.next()
-    print "Parsing Clinvar XML -- please wait."
+    event, root = next(context)
+    print("Parsing Clinvar XML -- please wait.")
     with open( mirror_dir + "/clinvar_hgvs.tsv", 'w' ) as f:
         ## get each record
         for event, elem in context:

--- a/clinvar/clinvar_hgvs.py
+++ b/clinvar/clinvar_hgvs.py
@@ -11,7 +11,8 @@ def get_hgvs_from_clinvarset( elem ):
     hgvs = []
     attributes = elem.xpath("ReferenceClinVarAssertion//Attribute[contains(@Type,'HGVS')]")
     for e in attributes:
-        hgvs.append(e.text)
+        if e.text is not None:
+            hgvs.append(e.text)
     if len(hgvs) == 0:
         hgvs.append('')
     return hgvs
@@ -71,7 +72,7 @@ if __name__ == '__main__':
     debug = True
 
     mirror_dir = os.path.dirname( os.path.realpath(__file__) ) + "/mirror/"
-    xml = mirror_dir + "/ClinVarFullRelease_00-latest.xml"
+    xml = mirror_dir + "ClinVarFullRelease_00-latest.xml"
     # xml = mirror_dir + "/test.xml"
 
     context = etree.iterparse(xml, events=('start', 'end'))


### PR DESCRIPTION
#### EDIT: Somehow I was on a completely different version locally and that makes this pull request very worthless and stupid.

~~Python 2 is unsupported. iI simply used python's `2to3-3.8` command to correct this.~~

~~Further testing brought light to two more errors, one where `replace()` was called on `None` objects. The other one was a double forward slash in the pathname.~~